### PR TITLE
move options before args

### DIFF
--- a/vvv
+++ b/vvv
@@ -323,7 +323,7 @@ elif [[ $action = 'teardown' || $action = 'delete' || $action = 'rm' ]]; then
 elif [[ $action = 'list' ]]; then
 
 	cd $path/www
-	find . -type d -print0 -maxdepth 1 -mindepth 1 | while IFS= read -d '' filename; do
+	find . -maxdepth 1 -mindepth 1 -type d -print0 | while IFS= read -d '' filename; do
 		filename=${filename:2}
 		if [[ $filename != 'default' && $filename != 'phpcs' && $filename != 'wp-cli' ]]; then
 			echo $filename


### PR DESCRIPTION
Options are not positional (-mindepth/-maxdepth affects tests specified before it as well as those specified after it).  Options should be specified before other arguments.

Current setup throws errors on certain installations (tested to show error on Linux Mint 15)
