### PR TITLE
Allow for tab completions

### DIFF
--- a/vvv
+++ b/vvv
@@ -143,8 +143,7 @@ if [[ $action = 'new' || $action = 'make' || $action = 'create' ]]; then
 		unset site
 	fi
 	while [ -z $site ]; do
-		echo -n "Name of new site directory: "
-		read site
+		read -e -p "Name of new site directory: " site
 
 		if [ -z $site ]; then
 			cecho "You must enter a directory name." red


### PR DESCRIPTION
Here's an enhancement, plus some shell script golf.

The '-e' flag for `read` allows for tab-completion, the '-p' flag passes prompt text. No more having to remember the entire path for the VVV install directory.
