### PR TITLE
Switch to using WP-CLI for installing/updating site files

### DIFF
--- a/vvv
+++ b/vvv
@@ -211,8 +211,8 @@ if [[ $action = 'new' || $action = 'make' || $action = 'create' ]]; then
 "\t\tcd -\n"\
 "else\n"\
 "\techo 'Updating WordPress in $site/htdocs...'\n"\
-"\twp core update --path=./htdocs && \\ \n"\
-"\t\twp core update-db --path=./htdocs\n"\
+"\twp core update --allow-root\\ \n"\
+"\t\twp core update-db --allow-root\n"\
 "fi\n" > vvv-init.sh
 
 	done_text


### PR DESCRIPTION
SVN is on its way out as the WordPress SCM system of choice, and it's
slower than an outright download of latest.zip. WP-CLI will install from
the latest stable version, and doesn't leave a messy trail of .svn
subdirectories.
