### PR TITLE
added a note about defining the path to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ To run the script from anywhere, you can place `vvv` in a folder included in you
 
 If you don't want to define the path each time you run the script, open the file and uncomment the line at the top defining `path`. Set that to the root folder of VVV on your machine. **Note:** You do not need to do this if VVV is installed in the default location (`~/vagrant-local/`).
 
+If you are asked to define the path, it must be absolute from your system root (at least when not the system default). 
+
+Examples: `~/Sites/vagrant-local/` did not work, nor did `Sites/vagrant-local`.
+
+Formatting the path absolutely, e.g. `/Users/myname/Sites/vagrant-local` is needed (substitute your User Name on your computer for 'myname' above).
+
 ## Usage
 
 Type `vvv` in the command line to use. None of the options are required: if a required piece of information is not included in the original command, the wizard will prompt you for it.


### PR DESCRIPTION
Just clarifying the documentation slightly. When prompted for the `path` I initially tried to use relative paths and they failed (even absolute from my user directory `~` failed).

Hopefully explaining that will save others some time and possible frustration.
