### PR TITLE
Allow easier control of WordPress versioning from vvv-init.sh

### DIFF
--- a/vvv
+++ b/vvv
@@ -264,7 +264,7 @@ if [[ $action = 'new' || $action = 'make' || $action = 'create' ]]; then
 			cecho "Version $version not found, try again" red
 			unset version
 		else
-			installversion=" --version=$version"
+			installversion=" --version=\$version"
 		fi
 	fi
 
@@ -281,7 +281,7 @@ if [[ $action = 'new' || $action = 'make' || $action = 'create' ]]; then
 				cecho "Version $version not found, try again" red
 				unset version
 			else
-				installversion=" --version=$version"
+				installversion=" --version=\$version"
 			fi
 		fi
 	done
@@ -372,13 +372,18 @@ if [[ $action = 'new' || $action = 'make' || $action = 'create' ]]; then
 		install_text='multisite-install'
 	fi
 
-	printf "if [ ! -d \"htdocs\" ]; then\n"\
-"\techo 'Installing WordPress $version in $site/htdocs...'\n"\
+	printf "version=$version\n"\
+"if [ ! -d \"htdocs\" ]; then\n"\
+"\techo \"Installing WordPress \$version in $site/htdocs...\"\n"\
 "\tmkdir ./htdocs\ncd ./htdocs\n"\
-"\twp core download --allow-root $installversion\n"\
+"\twp core download --allow-root$installversion\n"\
 "\twp core config --dbname=\"$db_name\" --dbuser=wp --dbpass=wp --dbhost=\"localhost\" --allow-root$wp_debug_text\n"\
 "\twp core $install_text --url=$domain --title=\"$site - A WordPress Site\" --admin_user=admin --admin_password=password --admin_email=demo@example.com --allow-root\n"\
 "\t\tcd -\n"\
+"else\n"\
+"\techo 'Updating WordPress in $site/htdocs...'\n"\
+"\twp core update --allow-root --force$installversion\n"\
+"\twp core update-db --allow-root\n"\
 "fi\n" > vvv-init.sh
 
 	done_text


### PR DESCRIPTION
- Use a single variable in vvv-init.sh to control WordPress version, so it can be easily updated for provisioning
- If WordPress is already installed, update WordPress upon provisioning, and forcing whatever version is set in script
