### PR TITLE
Archive site directory during site teardown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Provisioning Vagrant takes a couple of minutes, but this is a crucial step as it
 Deleting a site does the following:
 
 * Halts Vagrant (if running)
+* Archives the site's web root (if selected).
 * Deletes the site's web root (which deletes the `vvv-init.sh`, `wp-cli.yml`, and `vvv-hosts` files as well)
 * Deletes the file in the `nginx-config` folder pertaining to the site
 

--- a/vvv
+++ b/vvv
@@ -446,6 +446,18 @@ elif [[ $action = 'teardown' || $action = 'delete' || $action = 'rm' ]]; then
 
 			vagrant halt
 
+			# Archive the site folder
+			while [ -z $archive_site ]; do
+				echo -n "Archive (tar) entire site directory before delete (y/n)? "
+				read archive_site
+				if [ $archive_site = 'y' ]; then
+					# Tar the
+					echo -en "Archiving $site directory to $path... "
+					tar -zcvf $path/$site.tar.gz $path/www/$site
+					done_text
+				fi
+			done
+
 			# Delete the site folder
 			echo -en "Removing directory $site... "
 			rm -rf $path/www/$site


### PR DESCRIPTION
- Provide the option to archive (tar) the site directory before the site directory is deleted.
- Update README.md to include verbiage about archiving before site deletion.
